### PR TITLE
[#175497063] Use dot-crypto network-config in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+yarn-error.log

--- a/@types/markdown-include/index.d.ts
+++ b/@types/markdown-include/index.d.ts
@@ -1,0 +1,3 @@
+declare module 'markdown-include' {
+    export function compileFiles(path: string): Promise<any>;
+}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,16 @@
   "version": "1.0.0",
   "repository": "git@github.com:unstoppabledomains/docs-gitbook.git",
   "scripts": {
-    "check:links": "find . -type f -name '*.md' ! -path './node_modules/*' | xargs -l yarn markdown-link-check"
+    "check:links": "find . -type f -name '*.md' ! -path './node_modules/*' ! -path './templates/*' | xargs -l yarn markdown-link-check",
+    "render:cns-contracts": "ts-node ./templates/cns-smart-contracts-renderer.ts"
   },
   "devDependencies": {
+    "@types/node": "^14.14.6",
+    "ts-node": "^9.0.0",
+    "typescript": "^4.0.5",
+    "dot-crypto": "https://github.com/unstoppabledomains/dot-crypto.git",
+    "ejs": "^3.1.5",
+    "markdown-include": "^0.4.3",
     "markdown-link-check": "^3.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "render:cns-contracts": "ts-node ./templates/cns-smart-contracts-renderer.ts"
   },
   "devDependencies": {
+    "@types/ejs": "^3.0.5",
     "@types/node": "^14.14.6",
-    "ts-node": "^9.0.0",
-    "typescript": "^4.0.5",
     "dot-crypto": "https://github.com/unstoppabledomains/dot-crypto.git",
     "ejs": "^3.1.5",
     "markdown-include": "^0.4.3",
-    "markdown-link-check": "^3.8.1"
+    "markdown-link-check": "^3.8.1",
+    "ts-node": "^9.0.0",
+    "typescript": "^4.0.5"
   }
 }

--- a/templates/cns-smart-contracts-renderer.ts
+++ b/templates/cns-smart-contracts-renderer.ts
@@ -1,0 +1,99 @@
+import Path from 'path';
+import Fs from 'fs';
+import Ejs from 'ejs';
+import MarkdownInclude from 'markdown-include';
+import NetworkConfigJson from 'dot-crypto/src/network-config/network-config.json';
+
+const TemplatesDir = Path.join('templates');
+const ContractsDir = Path.join(TemplatesDir, 'contracts');
+const MarkdownFile = Path.join(TemplatesDir, 'markdown', 'cns-smart-contracts-markdown.json');
+const TemplateToRender = Path.join(TemplatesDir, 'cns-smart-contracts-template.md');
+const FileToRender = Path.join('src', 'domain-registry-essentials', 'cns-smart-contracts.md');
+const CotractTableTemplate = Fs.readFileSync(Path.join(ContractsDir, 'contract-table-template.ejs'), 'utf-8');
+const Networks: Record<number, string> = {
+    1: 'Mainnet',
+    3: 'Ropsten',
+    4: 'Rinkeby',
+    5: 'Goerli',
+    42: 'Kovan',
+};
+
+type Row = {
+    network: string,
+    address: string,
+    legacyAddresses: string[],
+}
+
+renderContractAddresses();
+
+function renderContractAddresses() {
+    console.log('Rendering [' + FileToRender + ']');
+    console.log('From template [' + TemplateToRender + ']');
+
+    let filesToInclude: string[] = [TemplateToRender];
+
+    for (let contract of getContracts()) {
+        generateContractTables(contract, filesToInclude);
+    }
+    compileContractTables(filesToInclude);
+    console.log('Done');
+}
+
+function getContracts(): Set<string> {
+    let contractSet = new Set<string>();
+
+    Object.keys(NetworkConfigJson.networks).forEach(id => {
+        Object.keys(NetworkConfigJson.networks[id].contracts).forEach(contract => contractSet.add(contract));
+    });
+    return contractSet;
+}
+
+function generateContractTables(contractName: string, filesToInclude: string[]) {
+    let rows: Array<Row> = [];
+    let contractHasLegacyAddresses: boolean = false;
+
+    for (const id of Object.keys(NetworkConfigJson.networks)) {
+        let contract = NetworkConfigJson.networks[id].contracts[contractName];
+        if (!contract) {
+            continue;
+        }
+        let legacyAddresses = contract.legacyAddresses;
+        contractHasLegacyAddresses = contractHasLegacyAddresses || legacyAddresses.length > 0;
+
+        rows.push(convertContractToRow(id, contract));
+    }
+    let contractTable = Ejs
+        .render(CotractTableTemplate, { rows, hasLegacyAddresses: contractHasLegacyAddresses })
+        .replace(/(^[ \t]*\n)/gm, ''); // remove new lines to render .md table properly
+
+    saveContractTable(contractName, contractTable, filesToInclude);
+}
+
+function convertContractToRow(networkId: string, contract): Row {
+    return <Row>{
+        network: Networks[networkId],
+        address: contract.address,
+        legacyAddresses: contract.legacyAddresses,
+    };
+}
+
+function saveContractTable(contractName: string, contractTable: string, filesToInclude: string[]) {
+    let filename = Path.join(ContractsDir, contractName + '.md');
+    Fs.writeFileSync(filename, contractTable, 'UTF-8');
+    filesToInclude.unshift(filename);
+    console.log('Contract table saved: ' + filename)
+}
+
+function compileContractTables(files: string[]) {
+    saveMarkdown(files);
+    MarkdownInclude.compileFiles(MarkdownFile);
+}
+
+function saveMarkdown(files: string[]) {
+    let markdown = {
+        "build": FileToRender,
+        "files": files,
+    }
+    Fs.writeFileSync(MarkdownFile, JSON.stringify(markdown, null, 4), 'UTF-8');
+    console.log('Markdown file saved: ' + MarkdownFile)
+}

--- a/templates/cns-smart-contracts-template.md
+++ b/templates/cns-smart-contracts-template.md
@@ -18,19 +18,7 @@ This section lists all the smart contracts that users can directly interact with
 
 `Registry` is the central smart contract, which stores all CNS domains. Implementing the ERC-721 non-fungible token standard, `Registry` defines domain ownership rules. It stores owner and `Resolver` addresses. For more details, see [Architecture overview - Registry](architecture-overview.md#registry).
 
-<table>
-    <th>Network</th>
-    <th>Contract address</th>
-    <tr>
-        <td>Mainnet</td>
-        <td><a href="https://etherscan.io/address/0xD1E5b0FF1287aA9f9A268759062E4Ab08b9Dacbe">0xD1E5b0FF1287aA9f9A268759062E4Ab08b9Dacbe</a></td>
-    </tr>
-    <tr>
-        <td>Rinkeby</td>
-        <td><a href="https://etherscan.io/address/0xAad76bea7CFEc82927239415BB18D2e93518ecBB">0xAad76bea7CFEc82927239415BB18D2e93518ecBB</a></td>
-    </tr>
-</table>
- 
+#include "templates/contracts/Registry.md"
 
 **Source code:** [contracts/Registry.sol](https://github.com/unstoppabledomains/dot-crypto/blob/master/contracts/Registry.sol)
 
@@ -38,33 +26,7 @@ This section lists all the smart contracts that users can directly interact with
 
 `Resolver` is the smart contract that stores domain records and provides methods for domain resolution. For more details, see [Architecture overview - Resolver](architecture-overview.md#resolver).
 
-<table>
-    <th>Network</th>
-    <th>Contract address</th>
-    <tr>
-        <td>Mainnet</td>
-        <td><a href="https://etherscan.io/address/0xb66DcE2DA6afAAa98F2013446dBCB0f4B0ab2842">0xb66DcE2DA6afAAa98F2013446dBCB0f4B0ab2842</a></td>
-    </tr>
-    <tr>
-        <td>Rinkeby</td>
-        <td><a href="https://etherscan.io/address/0x95AE1515367aa64C462c71e87157771165B1287A">0x95AE1515367aa64C462c71e87157771165B1287A</a></td>
-    </tr>
-</table>
-    <table>
-        <th>Network</th>
-        <th>Legacy addresses</th>
-        <tr>
-            <td>Mainnet</td>
-            <td><a
-                    href="https://etherscan.io/address/0xa1cac442be6673c49f8e74ffc7c4fd746f3cbd0d">0xa1cac442be6673c49f8e74ffc7c4fd746f3cbd0d
-                </a>
-                <a
-                    href="https://etherscan.io/address/0x878bc2f3f717766ab69c0a5f9a6144931e61aed3">0x878bc2f3f717766ab69c0a5f9a6144931e61aed3
-                </a>
-            </td>
-        </tr>
-    </table>
-    
+#include "templates/contracts/Resolver.md"
 
 **Source code:** [contracts/Resolver.sol](https://github.com/unstoppabledomains/dot-crypto/blob/master/contracts/Resolver.sol)
 
@@ -72,30 +34,7 @@ This section lists all the smart contracts that users can directly interact with
 
 `ProxyReader` provides an interface that allows users to fetch information about domains from both `Registry` and `Resolver` smart contracts in one call. For more details, see [Architecture overview - ProxyReader](architecture-overview.md#proxyreader).
 
-<table>
-    <th>Network</th>
-    <th>Contract address</th>
-    <tr>
-        <td>Mainnet</td>
-        <td><a href="https://etherscan.io/address/0xa6E7cEf2EDDEA66352Fd68E5915b60BDbb7309f5">0xa6E7cEf2EDDEA66352Fd68E5915b60BDbb7309f5</a></td>
-    </tr>
-    <tr>
-        <td>Rinkeby</td>
-        <td><a href="https://etherscan.io/address/0x3A2e74CF832cbA3d77E72708d55370119E4323a6">0x3A2e74CF832cbA3d77E72708d55370119E4323a6</a></td>
-    </tr>
-</table>
-    <table>
-        <th>Network</th>
-        <th>Legacy addresses</th>
-        <tr>
-            <td>Mainnet</td>
-            <td><a
-                    href="https://etherscan.io/address/0x7ea9Ee21077F84339eDa9C80048ec6db678642B1">0x7ea9Ee21077F84339eDa9C80048ec6db678642B1
-                </a>
-            </td>
-        </tr>
-    </table>
-    
+#include "templates/contracts/ProxyReader.md"
 
 **Source code:** [contracts/ProxyReader.sol](https://github.com/unstoppabledomains/dot-crypto/blob/master/contracts/ProxyReader.sol)
 
@@ -103,19 +42,7 @@ This section lists all the smart contracts that users can directly interact with
 
 `SignatureController` allows any account to submit management transactions on behalf of a token owner if an owner provides a signature for that call.
 
-<table>
-    <th>Network</th>
-    <th>Contract address</th>
-    <tr>
-        <td>Mainnet</td>
-        <td><a href="https://etherscan.io/address/0x82EF94294C95aD0930055f31e53A34509227c5f7">0x82EF94294C95aD0930055f31e53A34509227c5f7</a></td>
-    </tr>
-    <tr>
-        <td>Rinkeby</td>
-        <td><a href="https://etherscan.io/address/0x66a5e3e2C27B4ce4F46BBd975270BE154748D164">0x66a5e3e2C27B4ce4F46BBd975270BE154748D164</a></td>
-    </tr>
-</table>
- 
+#include "templates/contracts/SignatureController.md"
 
 **Source code:** [contracts/controllers/SignatureController.sol](https://github.com/unstoppabledomains/dot-crypto/blob/master/contracts/controllers/SignatureController.sol)
 
@@ -123,19 +50,7 @@ This section lists all the smart contracts that users can directly interact with
 
 `DomainZoneController` allows owners of a domain zone to mint subdomains. These subdomains can be managed only by the domain zone owners. For more details, see [Architecture Overview - Alternative Ownership Models](architecture-overview.md#alternative-ownership-models).
 
-<table>
-    <th>Network</th>
-    <th>Contract address</th>
-    <tr>
-        <td>Mainnet</td>
-        <td><a href="https://etherscan.io/address/0xeA70777e28E00E81f58b8921fC47F78B8a72eFE7">0xeA70777e28E00E81f58b8921fC47F78B8a72eFE7</a></td>
-    </tr>
-    <tr>
-        <td>Rinkeby</td>
-        <td><a href="https://etherscan.io/address/0x6f8F96A566663C1d4fEe70edD37E9b62Fe39dE5D">0x6f8F96A566663C1d4fEe70edD37E9b62Fe39dE5D</a></td>
-    </tr>
-</table>
- 
+#include "templates/contracts/DomainZoneController.md"
 
 **Source code:** [contracts/controllers/DomainZoneController.sol](https://github.com/unstoppabledomains/dot-crypto/blob/master/contracts/controllers/DomainZoneController.sol)
 
@@ -149,19 +64,7 @@ This section lists all the smart contracts that users can directly interact with
 
 `WhitelistedMinter` defines an interface for minting second-level domains. This smart contract is primarily used by the Unstoppable Domains team, but its interface also supports delegating minting process to other parties via [Meta Transactions](../managing-domains/meta-transactions.md). All calls to `WhitelistedMinter` are proxied to the `Registry` via the [MintingController](cns-smart-contracts.md#mintingcontroller) smart contract.
 
-<table>
-    <th>Network</th>
-    <th>Contract address</th>
-    <tr>
-        <td>Mainnet</td>
-        <td><a href="https://etherscan.io/address/0xd3fF3377b0ceade1303dAF9Db04068ef8a650757">0xd3fF3377b0ceade1303dAF9Db04068ef8a650757</a></td>
-    </tr>
-    <tr>
-        <td>Rinkeby</td>
-        <td><a href="https://etherscan.io/address/0xbcB32f13f90978a9e059E8Cb40FaA9e6619d98e7">0xbcB32f13f90978a9e059E8Cb40FaA9e6619d98e7</a></td>
-    </tr>
-</table>
- 
+#include "templates/contracts/WhitelistedMinter.md"
 
 **Source code:** [contracts/util/WhitelistedMinter.sol](https://github.com/unstoppabledomains/dot-crypto/blob/master/contracts/util/WhitelistedMinter.sol)
 
@@ -169,19 +72,7 @@ This section lists all the smart contracts that users can directly interact with
 
 `TwitterValidationOperator` is used when initiating Chainlink verification requests to link domain records with Twitter usernames.
 
-<table>
-    <th>Network</th>
-    <th>Contract address</th>
-    <tr>
-        <td>Mainnet</td>
-        <td><a href="https://etherscan.io/address/0xbb486C6E9cF1faA86a6E3eAAFE2e5665C0507855">0xbb486C6E9cF1faA86a6E3eAAFE2e5665C0507855</a></td>
-    </tr>
-    <tr>
-        <td>Rinkeby</td>
-        <td><a href="https://etherscan.io/address/0x1CB337b3b208dc29a6AcE8d11Bb591b66c5Dd83d">0x1CB337b3b208dc29a6AcE8d11Bb591b66c5Dd83d</a></td>
-    </tr>
-</table>
- 
+#include "templates/contracts/TwitterValidationOperator.md"
 
 **Source code:** [contracts/operators/TwitterValidationOperator.sol](https://github.com/unstoppabledomains/dot-crypto/blob/master/contracts/operators/TwitterValidationOperator.sol)
 
@@ -193,19 +84,7 @@ The Unstoppable Domains team reserves the right to mint second-level domains and
 
 The deployed version of the `Registry` smart contract only allows `MintingController` to mint second-level domains. This smart contract is used by [WhitelistedMinter](cns-smart-contracts.md#whitelistedminter) as a proxy.
 
-<table>
-    <th>Network</th>
-    <th>Contract address</th>
-    <tr>
-        <td>Mainnet</td>
-        <td><a href="https://etherscan.io/address/0xb0EE56339C3253361730F50c08d3d7817ecD60Ca">0xb0EE56339C3253361730F50c08d3d7817ecD60Ca</a></td>
-    </tr>
-    <tr>
-        <td>Rinkeby</td>
-        <td><a href="https://etherscan.io/address/0x51765307AeB3Df2E647014a2C501d5324212467c">0x51765307AeB3Df2E647014a2C501d5324212467c</a></td>
-    </tr>
-</table>
- 
+#include "templates/contracts/MintingController.md"
 
 **Source code:** [contracts/controllers/MintingController.sol](https://github.com/unstoppabledomains/dot-crypto/blob/master/contracts/controllers/MintingController.sol)
 
@@ -213,19 +92,7 @@ The deployed version of the `Registry` smart contract only allows `MintingContro
 
 `URIPrefixController` enables the Unstoppable Domains team to edit the token URI prefix.
 
-<table>
-    <th>Network</th>
-    <th>Contract address</th>
-    <tr>
-        <td>Mainnet</td>
-        <td><a href="https://etherscan.io/address/0x09B091492759737C03da9dB7eDF1CD6BCC3A9d91">0x09B091492759737C03da9dB7eDF1CD6BCC3A9d91</a></td>
-    </tr>
-    <tr>
-        <td>Rinkeby</td>
-        <td><a href="https://etherscan.io/address/0xe1d2e4B9f0518CA5c803073C3dFa886470627237">0xe1d2e4B9f0518CA5c803073C3dFa886470627237</a></td>
-    </tr>
-</table>
- 
+#include "templates/contracts/URIPrefixController.md"
 
 **Source code:** [contracts/controllers/URIPrefixController.sol](https://github.com/unstoppabledomains/dot-crypto/blob/master/contracts/controllers/URIPrefixController.sol)
 

--- a/templates/contracts/DomainZoneController.md
+++ b/templates/contracts/DomainZoneController.md
@@ -1,0 +1,13 @@
+<table>
+    <th>Network</th>
+    <th>Contract address</th>
+    <tr>
+        <td>Mainnet</td>
+        <td><a href="https://etherscan.io/address/0xeA70777e28E00E81f58b8921fC47F78B8a72eFE7">0xeA70777e28E00E81f58b8921fC47F78B8a72eFE7</a></td>
+    </tr>
+    <tr>
+        <td>Rinkeby</td>
+        <td><a href="https://etherscan.io/address/0x6f8F96A566663C1d4fEe70edD37E9b62Fe39dE5D">0x6f8F96A566663C1d4fEe70edD37E9b62Fe39dE5D</a></td>
+    </tr>
+</table>
+ 

--- a/templates/contracts/MintingController.md
+++ b/templates/contracts/MintingController.md
@@ -1,0 +1,13 @@
+<table>
+    <th>Network</th>
+    <th>Contract address</th>
+    <tr>
+        <td>Mainnet</td>
+        <td><a href="https://etherscan.io/address/0xb0EE56339C3253361730F50c08d3d7817ecD60Ca">0xb0EE56339C3253361730F50c08d3d7817ecD60Ca</a></td>
+    </tr>
+    <tr>
+        <td>Rinkeby</td>
+        <td><a href="https://etherscan.io/address/0x51765307AeB3Df2E647014a2C501d5324212467c">0x51765307AeB3Df2E647014a2C501d5324212467c</a></td>
+    </tr>
+</table>
+ 

--- a/templates/contracts/ProxyReader.md
+++ b/templates/contracts/ProxyReader.md
@@ -1,0 +1,24 @@
+<table>
+    <th>Network</th>
+    <th>Contract address</th>
+    <tr>
+        <td>Mainnet</td>
+        <td><a href="https://etherscan.io/address/0xa6E7cEf2EDDEA66352Fd68E5915b60BDbb7309f5">0xa6E7cEf2EDDEA66352Fd68E5915b60BDbb7309f5</a></td>
+    </tr>
+    <tr>
+        <td>Rinkeby</td>
+        <td><a href="https://etherscan.io/address/0x3A2e74CF832cbA3d77E72708d55370119E4323a6">0x3A2e74CF832cbA3d77E72708d55370119E4323a6</a></td>
+    </tr>
+</table>
+    <table>
+        <th>Network</th>
+        <th>Legacy addresses</th>
+        <tr>
+            <td>Mainnet</td>
+            <td><a
+                    href="https://etherscan.io/address/0x7ea9Ee21077F84339eDa9C80048ec6db678642B1">0x7ea9Ee21077F84339eDa9C80048ec6db678642B1
+                </a>
+            </td>
+        </tr>
+    </table>
+    

--- a/templates/contracts/Registry.md
+++ b/templates/contracts/Registry.md
@@ -1,0 +1,13 @@
+<table>
+    <th>Network</th>
+    <th>Contract address</th>
+    <tr>
+        <td>Mainnet</td>
+        <td><a href="https://etherscan.io/address/0xD1E5b0FF1287aA9f9A268759062E4Ab08b9Dacbe">0xD1E5b0FF1287aA9f9A268759062E4Ab08b9Dacbe</a></td>
+    </tr>
+    <tr>
+        <td>Rinkeby</td>
+        <td><a href="https://etherscan.io/address/0xAad76bea7CFEc82927239415BB18D2e93518ecBB">0xAad76bea7CFEc82927239415BB18D2e93518ecBB</a></td>
+    </tr>
+</table>
+ 

--- a/templates/contracts/Resolver.md
+++ b/templates/contracts/Resolver.md
@@ -1,0 +1,27 @@
+<table>
+    <th>Network</th>
+    <th>Contract address</th>
+    <tr>
+        <td>Mainnet</td>
+        <td><a href="https://etherscan.io/address/0xb66DcE2DA6afAAa98F2013446dBCB0f4B0ab2842">0xb66DcE2DA6afAAa98F2013446dBCB0f4B0ab2842</a></td>
+    </tr>
+    <tr>
+        <td>Rinkeby</td>
+        <td><a href="https://etherscan.io/address/0x95AE1515367aa64C462c71e87157771165B1287A">0x95AE1515367aa64C462c71e87157771165B1287A</a></td>
+    </tr>
+</table>
+    <table>
+        <th>Network</th>
+        <th>Legacy addresses</th>
+        <tr>
+            <td>Mainnet</td>
+            <td><a
+                    href="https://etherscan.io/address/0xa1cac442be6673c49f8e74ffc7c4fd746f3cbd0d">0xa1cac442be6673c49f8e74ffc7c4fd746f3cbd0d
+                </a>
+                <a
+                    href="https://etherscan.io/address/0x878bc2f3f717766ab69c0a5f9a6144931e61aed3">0x878bc2f3f717766ab69c0a5f9a6144931e61aed3
+                </a>
+            </td>
+        </tr>
+    </table>
+    

--- a/templates/contracts/SignatureController.md
+++ b/templates/contracts/SignatureController.md
@@ -1,0 +1,13 @@
+<table>
+    <th>Network</th>
+    <th>Contract address</th>
+    <tr>
+        <td>Mainnet</td>
+        <td><a href="https://etherscan.io/address/0x82EF94294C95aD0930055f31e53A34509227c5f7">0x82EF94294C95aD0930055f31e53A34509227c5f7</a></td>
+    </tr>
+    <tr>
+        <td>Rinkeby</td>
+        <td><a href="https://etherscan.io/address/0x66a5e3e2C27B4ce4F46BBd975270BE154748D164">0x66a5e3e2C27B4ce4F46BBd975270BE154748D164</a></td>
+    </tr>
+</table>
+ 

--- a/templates/contracts/TwitterValidationOperator.md
+++ b/templates/contracts/TwitterValidationOperator.md
@@ -1,0 +1,13 @@
+<table>
+    <th>Network</th>
+    <th>Contract address</th>
+    <tr>
+        <td>Mainnet</td>
+        <td><a href="https://etherscan.io/address/0xbb486C6E9cF1faA86a6E3eAAFE2e5665C0507855">0xbb486C6E9cF1faA86a6E3eAAFE2e5665C0507855</a></td>
+    </tr>
+    <tr>
+        <td>Rinkeby</td>
+        <td><a href="https://etherscan.io/address/0x1CB337b3b208dc29a6AcE8d11Bb591b66c5Dd83d">0x1CB337b3b208dc29a6AcE8d11Bb591b66c5Dd83d</a></td>
+    </tr>
+</table>
+ 

--- a/templates/contracts/URIPrefixController.md
+++ b/templates/contracts/URIPrefixController.md
@@ -1,0 +1,13 @@
+<table>
+    <th>Network</th>
+    <th>Contract address</th>
+    <tr>
+        <td>Mainnet</td>
+        <td><a href="https://etherscan.io/address/0x09B091492759737C03da9dB7eDF1CD6BCC3A9d91">0x09B091492759737C03da9dB7eDF1CD6BCC3A9d91</a></td>
+    </tr>
+    <tr>
+        <td>Rinkeby</td>
+        <td><a href="https://etherscan.io/address/0xe1d2e4B9f0518CA5c803073C3dFa886470627237">0xe1d2e4B9f0518CA5c803073C3dFa886470627237</a></td>
+    </tr>
+</table>
+ 

--- a/templates/contracts/WhitelistedMinter.md
+++ b/templates/contracts/WhitelistedMinter.md
@@ -1,0 +1,13 @@
+<table>
+    <th>Network</th>
+    <th>Contract address</th>
+    <tr>
+        <td>Mainnet</td>
+        <td><a href="https://etherscan.io/address/0xd3fF3377b0ceade1303dAF9Db04068ef8a650757">0xd3fF3377b0ceade1303dAF9Db04068ef8a650757</a></td>
+    </tr>
+    <tr>
+        <td>Rinkeby</td>
+        <td><a href="https://etherscan.io/address/0xbcB32f13f90978a9e059E8Cb40FaA9e6619d98e7">0xbcB32f13f90978a9e059E8Cb40FaA9e6619d98e7</a></td>
+    </tr>
+</table>
+ 

--- a/templates/contracts/contract-table-template.ejs
+++ b/templates/contracts/contract-table-template.ejs
@@ -1,0 +1,29 @@
+<table>
+    <th>Network</th>
+    <th>Contract address</th>
+
+    <% for (var i = 0; i < rows.length; i++) {%>
+    <tr>
+        <td><%= rows[i].network %></td>
+        <td><a href="https://etherscan.io/address/<%= rows[i].address %>"><%= rows[i].address %></a></td>
+    </tr>
+    <%}%>
+</table>
+ <% if (hasLegacyAddresses) { %>
+    <table>
+        <th>Network</th>
+        <th>Legacy addresses</th>
+        <% for (var i = 0; i < rows.length; i++) {%>
+        <% if(rows[i].legacyAddresses.length === 0) { continue; }%>
+        <tr>
+            <td><%= rows[i].network %></td>
+            <% var legacyAddresses = rows[i].legacyAddresses; %>
+            <td><% for (var j = 0; j < legacyAddresses.length; j++) {%><a
+                    href="https://etherscan.io/address/<%= legacyAddresses[j] %>"><%= legacyAddresses[j]%>
+                </a>
+                <%}%>
+            </td>
+        </tr>
+        <%}%>
+    </table>
+    <% } %>

--- a/templates/markdown/cns-smart-contracts-markdown.json
+++ b/templates/markdown/cns-smart-contracts-markdown.json
@@ -1,0 +1,15 @@
+{
+    "build": "src/domain-registry-essentials/cns-smart-contracts.md",
+    "files": [
+        "templates/contracts/TwitterValidationOperator.md",
+        "templates/contracts/ProxyReader.md",
+        "templates/contracts/Resolver.md",
+        "templates/contracts/DomainZoneController.md",
+        "templates/contracts/URIPrefixController.md",
+        "templates/contracts/WhitelistedMinter.md",
+        "templates/contracts/MintingController.md",
+        "templates/contracts/SignatureController.md",
+        "templates/contracts/Registry.md",
+        "templates/cns-smart-contracts-template.md"
+    ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
       "es6"
     ],
     "strict": true,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "strictPropertyInitialization": false,
     "resolveJsonModule": true,
     "esModuleInterop": true,
@@ -15,6 +15,7 @@
     "rootDirs": [
       "src"
     ],
+    "typeRoots": ["node_modules/@types", "./@types"]
   },
   "include": [
     "src"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "moduleResolution": "node",
+    "lib": [
+      "es6"
+    ],
+    "strict": true,
+    "noImplicitAny": false,
+    "strictPropertyInitialization": false,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "outDir": "build",
+    "rootDirs": [
+      "src"
+    ],
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/node@^14.14.6":
+  version "14.14.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.6.tgz#146d3da57b3c636cc0d1769396ce1cfa8991147f"
+  integrity sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==
+
 ajv@^6.12.3:
   version "6.12.4"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
@@ -17,6 +22,13 @@ ajv@^6.12.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+  dependencies:
+    color-convert "^1.9.0"
+
 ansi-styles@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
@@ -24,6 +36,11 @@ ansi-styles@^4.1.0:
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 asn1@~0.2.3:
   version "0.2.4"
@@ -36,6 +53,11 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
+
+async@0.9.x:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
+  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
 
 async@^3.2.0:
   version "3.2.0"
@@ -57,6 +79,11 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
 
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
@@ -64,10 +91,32 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 chalk@^4.0.0:
   version "4.1.0"
@@ -77,12 +126,24 @@ chalk@^4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+color-convert@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 color-name@~1.1.4:
   version "1.1.4"
@@ -101,6 +162,11 @@ commander@^5.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
 core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -118,6 +184,15 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
+"dot-crypto@https://github.com/unstoppabledomains/dot-crypto.git":
+  version "1.1.0"
+  resolved "https://github.com/unstoppabledomains/dot-crypto.git#a744cc0d13d58af550a8881380e585ef1f8f9755"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -125,6 +200,18 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ejs@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.5.tgz#aed723844dc20acb4b170cd9ab1017e476a0d93b"
+  integrity sha512-dldq3ZfFtgVTJMLjOe+/3sROTzALlL9E34V4/sDtUd/KlBSS0s6U1/+WPE1B4sj9CXHJpL1M6rhNJnc9Wbal9w==
+  dependencies:
+    jake "^10.6.1"
+
+escape-string-regexp@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 extend@~3.0.2:
   version "3.0.2"
@@ -150,6 +237,13 @@ fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+filelist@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.1.tgz#f10d1a3ae86c1694808e8f20906f43d4c9132dbb"
+  integrity sha512-8zSK6Nu0DQIC08mUC46sWGXi+q3GGpKydAG36k+JDba6VRpkevvOWUW5a/PhShij4+vHT9M+ghgG7eM+a9JDUQ==
+  dependencies:
+    minimatch "^3.0.4"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -184,6 +278,11 @@ har-validator@~5.1.3:
   dependencies:
     ajv "^6.12.3"
     har-schema "^2.0.0"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -227,6 +326,16 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+
+jake@^10.6.1:
+  version "10.8.2"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.8.2.tgz#ebc9de8558160a66d82d0eadc6a2e58fbc500a7b"
+  integrity sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==
+  dependencies:
+    async "0.9.x"
+    chalk "^2.4.2"
+    filelist "^1.0.1"
+    minimatch "^3.0.4"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -273,6 +382,18 @@ lodash@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
+markdown-include@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/markdown-include/-/markdown-include-0.4.3.tgz#bac6555402c6da93a0f52952225dfb9a6ccc731b"
+  integrity sha1-usZVVALG2pOg9SlSIl37mmzMcxs=
+  dependencies:
+    q "^1.2.0"
+
 markdown-link-check@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/markdown-link-check/-/markdown-link-check-3.8.1.tgz#526cdf27fdac2c88fc98687bbc0ebb0928452a14"
@@ -311,6 +432,13 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   dependencies:
     mime-db "1.44.0"
 
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 ms@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -340,6 +468,11 @@ punycode@2.x.x, punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+q@^1.2.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
+  integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
 qs@~6.5.2:
   version "6.5.2"
@@ -382,6 +515,19 @@ safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+source-map-support@^0.5.17:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 sshpk@^1.7.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
@@ -396,6 +542,13 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
+
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
 
 supports-color@^7.1.0:
   version "7.1.0"
@@ -412,6 +565,17 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
+ts-node@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.0.0.tgz#e7699d2a110cc8c0d3b831715e417688683460b3"
+  integrity sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
@@ -423,6 +587,11 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+typescript@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -444,3 +613,8 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/ejs@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/ejs/-/ejs-3.0.5.tgz#95a3a1c3d9603eba80fe67ff56da1ba275ef2eda"
+  integrity sha512-k4ef69sS4sIqAPW9GoBnN+URAON2LeL1H0duQvL4RgdEBna19/WattYSA1qYqvbVEDRTSWzOw56tCLhC/m/IOw==
+
 "@types/node@^14.14.6":
   version "14.14.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.6.tgz#146d3da57b3c636cc0d1769396ce1cfa8991147f"


### PR DESCRIPTION
This PR introduces the automatic rendering of tables with CNS Smart Contract addresses using [network-config](https://github.com/unstoppabledomains/dot-crypto/blob/master/src/network-config/network-config.json).

Usage: 
- Existing contracts can be updated by running `yarn render:cns-contracts`. 
- New contracts should be included by adding `#include "templates/contracts/<ContractName>.md"` in needed section of [cns-smart-contracts-template.md](src/domain-registry-essentials/templates/cns-smart-contracts-template.md). Note: `<ContractName>` should match name in [network-config](https://github.com/unstoppabledomains/dot-crypto/blob/master/src/network-config/network-config.json).
- Updates to [cns-smart-contracts.md](src/domain-registry-essentials/cns-smart-contracts.md) should be done only by editing [cns-smart-contracts-template.md](src/domain-registry-essentials/templates/cns-smart-contracts-template.md) for proper rendering. 

Branch preview in GitBook: https://app.gitbook.com/@unstoppable-domains/s/unstoppable-docs-dev/v/use-dot-crypto-config-in-docs/domain-registry-essentials/cns-smart-contracts

Notice also the new 'Templates' section at the bottom. 
